### PR TITLE
fixing syntax errors in docs

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -4,8 +4,9 @@ Advanced analysis options
 =========================
 
 .. _incompsampling: 
+
 Accounting for *non-random* incomplete taxon sampling in diversification studies
-----------------------------------------------
+--------------------------------------------------------------------------------
 It is well-known that incomplete taxon sampling can bias analyses of speciation and extinction from phylogenetic trees. If you have an incompletely-sampled tree (e.g., some fraction < 1 of the total extant species richness of your focal taxon), you can easily specify this sampling fraction to generate unbiased estimates of speciation and extinction under the assumption that *species are missing at random from the tree*. In your controlfile, you can specify the percentage of species that have been sampled by setting the ``globalSamplingFraction`` parameter. Specifically, you should have the following settings in your control file::
 
 	useGlobalSamplingProbability = 1
@@ -98,7 +99,7 @@ BAMM is sufficiently flexible as to allow a number of permutations on these gene
  	betaShiftInit = 0.0
  
 Accounting for phylogenetic uncertainty
-----------------------------------------
+---------------------------------------
 
 Some researchers consider it important to account for phylogenetic uncertainty when performing macroevolutionary analyses. At present, there is no direct way of accounting for phylogenetic uncertainty in BAMM itself. It remains unclear whether phylogenetic uncertainty generally matters for the sorts of conclusions obtained with BAMM. My (DLR) personal view is that phylogenetic uncertainty is very much an issue for **some types** of results obtained using BAMM (and other programs), and (usually) not an issue at all for many other types of results. 
 
@@ -110,7 +111,7 @@ Although BAMM does not directly allow modeling phylogenetic uncertainty, it is s
 
 
 Understanding the event data file
-----------------------------------------
+---------------------------------
 
 .. _eventdatafile:
 
@@ -141,13 +142,5 @@ Each row of the event data file is a *macroevolutionary rate process*. Each samp
 	
 ``lambdainit,lambdashift,muinit,mushift`` or ``betainit,betashift``
 	Evolutionary rate parameters for the exponential change model 
-
-
-
-
-
-
-
-
 
 

--- a/doc/source/bammgraph.rst
+++ b/doc/source/bammgraph.rst
@@ -3,7 +3,6 @@
 BAMM graph gallery
 ==================
 
-
 Tree-wide diversification heterogeneity
 ---------------------------------------
 
@@ -59,7 +58,7 @@ Evolutionary rates through time for whales, color version with density shading.
 R code :download:`here<rcode/rate_through_time_whales_color.R>`
 
 Bayes factors
-----------------
+-------------
 
 .. _pwbffig: 
 .. figure:: figs/xBayesFactorsJetzPW.png
@@ -69,7 +68,7 @@ Bayes factors
    Pairwise matrix of Bayes factors for the JEA bird phylogeny (Jetz *et al*, **Nature**, 491:444-448, 2012). Orange/red colors involve decisive comparisons between models (Bayes factor evidence > 100). Color bar on right gives interpretation of colors in units of log(Bayes factor). Models with fewer than 50 processes fare poorly when compared to models with approximately 55 - 65 processes. This suggests the presence of massive diversification rate heterogeneity across the avian phylogeny. R code :download:`here<rcode/BF_pairwise.R>`.
  
 Maximum shift credibility configuration
--------------------------------
+---------------------------------------
 
 .. _maxcredibility: 
 .. figure:: figs/xMaxCredShiftTree.png
@@ -80,7 +79,7 @@ Maximum shift credibility configuration
       
       
 Cumulative shift probability
------------------------------
+----------------------------
 .. _cst: 
 .. figure:: figs/xCumShiftTree.png
    :width: 700

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,7 @@ release = '1.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ["template.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -15,23 +15,23 @@ This paper contains a description of the model, the reversible jump MCMC impleme
 
 
 How much data does it need?
------------------------
+---------------------------
 **Not much**. There is no general rule here, but if your dataset is large enough to consider doing any other sort of diversification analysis, then it is probably large enough for BAMM. The whale diversification analysis shown in the :ref:`graph gallery<bammgraph>` uses a time-calibrated tree with 89 tips. We've had good success using BAMM on trees that are considerably smaller than this. 
 
 
 
 BAMM extensions
------------------------
+---------------
 
 We are currently testing extensions of BAMM that allow modeling evolutionary dynamics under a much greater range of phenotypic evolutionary scenarios, as well as the incorporation of paleontological data. Bleeding edge releases of BAMM can be obtained from here (**link**).
 
 
 Problems running BAMM
-......................
+.....................
 
 
 I can't get BAMM to run on my system
------------------------------------------
+------------------------------------
 
 **Under construction**
 
@@ -39,7 +39,7 @@ Brief list of possible things to try.
 
 
 I get an error message when I try to run BAMM
-----------------------------------------------
+---------------------------------------------
 
 **Under construction**
 
@@ -50,7 +50,7 @@ This section needs to explain common error messages obtained with BAMM. For exam
 implies that BAMM is having a hard time reading your control file. Are you spelling the control file name correctly (including the extension), and/or are you sure it is in the correct directory?
 
 Stepwise troubleshooting
------------------------------------------
+------------------------
 
 The simplest way to localize potential problems is to first try to load your data without doing anything else. You can do this by setting the following parameter in your controlfile::
 
@@ -65,7 +65,7 @@ If these issues fail to resolve the problem, and if you cannot
 
  
 I get a system error (segfault or equivalent) when running BAMM
----------------------------------------------------------------------
+---------------------------------------------------------------
 
 Other possible errors may arise, not discussed above. This may include errors that mention "Segmentation fault", or "Floating point error". Please contact Carlos Anderson (**link**) or Dan Rabosky (**link**) with information about system errors. Please send us as much information as possible, so that we can try to replicate the problem. You should include (if possible) the data files that led to the problem, your control file, and as much information as possible about your operating system and computer architecture. On unix/linux/OSX, you should be able to obtain most of this information using::
 	
@@ -95,7 +95,7 @@ The model and approximations
 ....................................
 
 How can BAMM detect diversity-dependent changes in speciation rates?
-------------------------------------------------------------------------
+--------------------------------------------------------------------
 
 BAMM models the dynamics of speciation and extinction within rate regimes using an exponential change function. The speciation rate :math:`\lambda` at any point in time is modeled as
 
@@ -112,5 +112,5 @@ As an aside, the user is encouraged to remember that all analytically tractable 
  
  
 Other questions
-.................
+...............
  

--- a/doc/source/postprocess.rst
+++ b/doc/source/postprocess.rst
@@ -1,10 +1,11 @@
 .. _bammtools:
 
 Analyzing BAMM output with BAMMtools
-===============================================
+====================================
 
 Brief
-................
+.....
+
 The R package **BAMMtools** contains almost everything you need to analyze and visualize evolutionary rate dynamics from BAMM output. You will need to install this package. To install BAMMtools, type the following in your R console::
 
 	> install.packages("BAMMtools")
@@ -12,7 +13,7 @@ The R package **BAMMtools** contains almost everything you need to analyze and v
 The information below is a brief overview to get you started - there is much more than can be done. The end of this page contains a :ref:`sample BAMMtools workflow<bammtoolsworkflow>` for analyzing rates and rate shifts.
 
 BAMM output files
-............................
+.................
 
 BAMM generates three primary output files. The first is the *mcmc data file*, which contains several pieces of information about the MCMC simulation that may be useful in diagnosing convergence. The most important pieces of information from this file are the number of shift events, the log-likelihood of the data, and the log-prior probability of the data, for each sample from the posterior. 
 
@@ -24,6 +25,7 @@ Finally, BAMM will (optionally) generate a second MCMC output file that contains
 
 Diagnosing convergence
 ......................
+
 The first question after running any MCMC simuluation should always be: *did my run converge?* While it may be difficult to prove convergence in an absolute sense, there are a few simple checks you can do. First, you can plot the log-likelihood trace of your MCMC output file::
 
 	> mcmcout <- read.csv("mcmc_out.txt", header=T)
@@ -49,7 +51,7 @@ In general, we want these to be at least 200 (and 200 is on the low side, but mi
 If you are having trouble with convergence, please see the section on :ref:`troubleshooting convergence issues<fixbammconvergence>`. 
 
 General BAMMtools workflow
-..........................................
+..........................
 
 The general analyses described in this section apply both to **speciation-extinction** and **phenotypic evolution** studies. As such, they are not treated separately. The primary difference is the name of the parameters (:math:`\lambda` and :math:`\mu` for speciation and extinction, and :math:`\beta` for trait evolution).
 
@@ -80,6 +82,7 @@ Now we will focus on a few simple analyses that you can do with the 'BAMM-data' 
 
 Analyzing locations of rate shifts
 ----------------------------------
+
 Once you have established there there is at least some evidence for heterogeneous evolutionary dynamics in your dataset, the obvious question is: where are these rate shifts? In the BAMM framework, this is a deceptively simple question, because BAMM does not generate a single *best* rate shift configuration. In the BAMM framework, many different shift configurations may be (more-or-less) equally plausible. BAMM samples shift configurations in proportion to their posterior probability. In principle, this means that each sample from your posterior contains a potentially unique configuration of regime shift events. 
 
 A conceptual discussion of the meaning of rate shifts is included in this documentation and it is **strongly recommended** that you :ref:`read this section before continuing<rateshifts>`. Approaches that identify a single best shift configuration (e.g., stepwise AIC, or other approaches that simply maximize the likelihood) are inherently limited by their assumption that the model with the best information theoretic score (AIC etc) is *the* model, given the candidate set of models. However, for most real datasets, the best rate shift configuration is merely one of a large number of possible rate shift configurations that have similar probabilities. The BAMM philosophy is largely oriented around addressing this. 
@@ -191,6 +194,7 @@ And you can see that the non-dolphin (background) rate is much lower than the do
 
 Branch-specific evolutionary rates
 ----------------------------------
+
 BAMM can estimate marginal distributions of evolutionary rates for any point in time along a phylogenetic tree (this is what the the function ``plot.bammdata`` is going to generate a phylorate plot). Sometimes, however, it is useful to have mean rates for individual branches. To pull out the mean rates for individual branches, you can use the function ``getMeanBranchLengthTree`` (see the ``?getMeanBranchLengthTree`` for help on this function). The function generates a copy of your original phylogenetic tree, but where each branch length is replaced by the mean of the marginal distribution of evolutionary rates on each branch. The function can be used to extract branch-specific mean rates of speciation, extinction, net diversification, and trait evolution.
 
 Plotting rate-through-time curves
@@ -256,7 +260,8 @@ Please see code underlying some BAMM graph gallery plots for more on working wit
 
 
 Computing Bayes factors
-----------------------------------
+-----------------------
+
 BAMMtools makes it easy to compute Bayes factor evidence in favor of one model relative to another. The disadvantage of Bayes factors is that they provide a measure of pairwise model support and don't necessarily identify a single best model (this isn't necessarily bad: *is* there a single best model?). An advantage of Bayes factors as that they allow model comparisons to be made *independent of the prior on the model*. In BAMM, you specified a hyperprior distribution on the number of shift regimes, and this will have some effect on your posterior model probabilities, so it can be useful to look at the Bayes factor matrix for model comparisons.
 
 This analysis assumes that you have generated an *MCMC output file* involving simulation from the **prior only**. BAMMtools will need to perform explicit comparisons of the prior and posterior model probabilities. Assuming you have files *prior_mcmc_out.txt* and *post_mcmc_out.txt* for your analysis, you can compute a pairwise Bayes factor matrix as::
@@ -268,7 +273,7 @@ This analysis assumes that you have generated an *MCMC output file* involving si
 and this will return a pairwise matrix of Bayes factors. It is very important to recognize that model probabilities for rarely sampled models are likely to be inaccurate. Hence, BAMM will return a matrix with missing values (NA) if a given model was insufficiently sampled to estimate posterior or prior odds (see the ``threshpost`` and ``threshprior`` arguments in ?computeBayesFactors). Also keep in mind that any model sampled too infrequently to estimate model odds is also a model that is highly improbable given the data, so the missing Bayes factors aren't really something to worry about. Please see the analysis detailed :ref:`here<pwbffig>` for analysis and visualization of pairwise Bayes factors for a large set of candidate models.
 
 BAMMtools workflows
---------------------------------
+-------------------
 
 .. _bammtoolsworkflow:
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -25,7 +25,7 @@ Your phylogenetic tree must be **ultrametric**, it must be **fully bifurcating**
 If all of those checks are good, we can move on.
 
 Control file
-----------------
+------------
 
 To run ``bamm``, you must always specify a *control file*. The control file contains all of the settings necessary to run the program on your dataset, including the name(s) of the input files you seek to analyze. The easiest way to run BAMM is to place the control file, and all files to be analyzed (e.g., the phylogeny) in the same directory as the **BAMM** application. If your control file is named ``myControlFile.txt``, you would run BAMM as follows (on the OSX operating system)::
 
@@ -51,8 +51,10 @@ BAMM comes with example control files (located in the directory ``examples/`` ).
 There are many possible settings that can be tweaked in BAMM. The next two sections give you a simple recipe for running the program on your data, depending on whether you are analyzing speciation-extinction rates or phenotypic evolutionary rates. **There is no guarantee that these settings will work for your dataset**.
 
 .. _speciationextinctionquick:
+
 Speciation-extinction analyses
---------------------------
+------------------------------
+
 You must have an ultrametric phylogenetic tree. For optimal performance with the *quick-start* settings, the tree should be calibrated in units of millions of years (e.g, a branch length of 1.0 implies 1.0 million years). As a template, use the example file linked :download:`here (divcontrol_template.txt)<divcontrol_template.txt>`. The default values in this file work reasonably well for most trees calibrated on million-year timescales but may not work for your data. Here's an example :download:`phylogenetic tree of whales<examples/whaletree.txt>` that is used elsewhere in this documentation.
 
 If you open the template file, you'll see that there are extensive comments. For each parameter in the BAMM control file, we've included a brief description on the line following the parameter. For example: ::
@@ -98,7 +100,7 @@ For speciation-extinction analyses BAMM can analytically account for incomplete 
 .. _phenotypicquick:
 
 Phenotypic evolution
---------------------------
+--------------------
 
 This section is quite redundant with the preceding section on **speciation-extinction**, with a few differences.
 
@@ -147,7 +149,7 @@ You'll want to increase all of these once you are sure the program is correctly 
 
 
 BAMM output: brief
-----------------
+------------------
 
 BAMM generates multiple types of output files. These (usually) include:
 

--- a/doc/source/rateshifts.rst
+++ b/doc/source/rateshifts.rst
@@ -2,12 +2,13 @@
 .. _rateshifts: 
 
 Interpreting Rate Shifts on Phylogenies
-==========================
+=======================================
 
 This section details some of the most common conceptual issues that can arise when interpreting rate shifts on phylogenetic trees. Many studies have attempted to identify ***the*** rate shifts within a given dataset. In the BAMM framework, there is no single set of independent rate shifts waiting to be identified. Rather, BAMM identifies *configurations* of rate shifts - sets of shifts that are sampled together - and enables us to compute relative probability of those configurations. Three *shift configurations* sampled with BAMM during simulation of the posterior are shown :ref:`here<dtmulti>`.
  
 The BAMM model is an approximation
-.............
+..................................
+
 The models of diversification and trait evolution implemented in BAMM are approximations. This is true for any statistical model that you can use to extract information from data. Let's consider a few assumptions of the models implemented in BAMM. The model assumes that a relatively small number of discrete shift events can explain the data (sort of.... it is more that the marginal likelihood of any particular model is implicitly penalized by the addition of more parameters).It is possible that many shifts in evolutionary dynamics change in a discrete fashion (e.g., the classic "key innovation" scenario), but it is also possible that major changes in dynamics occur through a number of sequential changes in some general region of a tree (see figure below).
 
 
@@ -25,7 +26,8 @@ This is not a weakness *per se* of BAMM, and it applies to all other "macroevolu
 
 
 Multiple distinct rate shift configurations can explain your data
-.............
+.................................................................
+
 With most phylogenetic datasets, it is unlikely that you will be able to identify the specific branches on which rate shifts have occurred with extremely high confidence. More typically, you will be unable to exclude several different shift configurations that potentially account for a given pattern of phylogenetic branching or phenotypic diversity. 
 
 Currently, stepwise AIC and other model selection approaches are used to identify a single best set of rate shifts. We will single out some work that we have previously been involved with as an example of this type of approach. In Rabosky et al. (Proc. R. Soc. B, ###:###, 2007) and Alfaro et al. (PNAS ###:###, 2009), an information-theoretic model selection procedure is used to fit a set of models to phylogenetic data. Model complexity starts at 0, with the assumption that a single set of evolutionary rate parameters apply across an entire phylogeny. The algorithm then considers a more complex model, with two distinct evolutionary rate partitions across the tree. The actual likelihoods and AIC scores reported in these papers (and most subsequent papers that have cited them) tell us only about the relative fit of a model with *X* rate shifts relative to a model with *Y* rate shifts. There is typically no information in these analyses that provides the relative probability of different rate shift :ref:`configurations<dtmulti>`. All we get is the maximum likelihood *point estimate* of the best-fit shift configuration, but we get no information regarding our confidence in that estimate relative to other shift configurations with an identical number of rate shifts. 
@@ -52,7 +54,7 @@ Simply speaking, reporting only the *maximum likelihood* shift location on a phy
 Addressing this issue is one of the primary reasons that we created BAMM.
 
 Is this really a problem?
------------------- 
+-------------------------
  
 **Yes**.
 
@@ -69,7 +71,8 @@ Overall, we have very strong evidence for a shift in diversification dynamics so
 
 
 Rate shifts are not independent
-.............
+...............................
+
 Marginal shift probabilities - the probability that a shift occurred on a given branch, ignoring everything else in the tree - are useful, but they are **not independent** of shifts occurring elsewhere on the tree. The marginal shift probabilities in the figure :ref:`above<whalemarg1>` cannot be treated as independent. In fact, the joint probability of a shift occurring on any two of the 3 principal branches (e.g., those with probs 0.05, 0.38, and 0.56) is approximately zero for all combinations. In other words, if you have a shift on one of these 3 branches for a given sample from the posterior, the conditional probability of a shift on any of the other branches leading to the dolphin clade is approximately zero. 
 
 Put simply: there is very strong (prob > 0.99) evidence for a shift in dynamics somewhere along the ancestral 3 branches leading to the core dolphin clade. But there is only evidence for one such shift. Almost every sample from the posterior has a shift on at least one of these 3 branches, but no sample has a shift on more than one of these branches. 
@@ -77,11 +80,13 @@ Put simply: there is very strong (prob > 0.99) evidence for a shift in dynamics 
 Because of the non-independence of rate shift configurations, it doesn't really make sense to show - in a single tree - all the rate shifts discovered by BAMM. A good (but imperfect) analogy for thinking about rate shift configurations and their potential non-independence comes from Bayesian phylogenetic analysis. Any given shift configuration is like a phylogenetic tree sampled from a posterior. Some trees in that posterior will be incompatible with others. Trying to show all the rate shifts at once on a single tree, or reporting them as though they are independent, is sort of like trying to show a phylogenetic tree where you show all recovered clades at the same time. Suppose in a Bayesian phylogenetic analysis of 3 clades (A, B, C) you recover, each with probability 0.5, the following topologies: (A,(B,C)) and ((A,B),C). These topologies are incompatible, and it doesn't make sense to demand a single phylogenetic tree that represents all sampled clades within a single tree. The solution in phylogenetics is to collapse these incompatible topologies to a consensus tree with a polytomy. Showing all rate shifts recovered with BAMM on a single phylogenetic tree is a bit like showing a consensus phylogeny with polytomies: it isn't the "true" tree, but it summarizes some of the total run information.
 
 Meaningful reporting of "rate shifts" in the BAMM framework
-.............
+...........................................................
+
 There are many types of information that can be extracted from a BAMM run. Here we describe several useful methods of summarizing and visualizing shift information from a BAMM analysis.
 
 Shift configurations sampled with BAMM
------------------
+--------------------------------------
+
 One of the most important ideas to grasp regarding BAMM is that BAMM simulates a posterior distribution of *shift configurations* on phylogenetic trees. Hence, every sample from a posterior simulated with BAMM may contain a potentially unique configuration of rate shifts. Here are 3 different shift configurations for the primates dataset included in BAMMtools. The fourth tree is a phylorate plot, showing instantaneous (marginal) phenotypic evolutionary rates at fine-grained set of points along the phylogeny. Note that the shift configurations are different for each sample from the posterior. 
 
 .. _primateconfigs:  
@@ -91,7 +96,8 @@ One of the most important ideas to grasp regarding BAMM is that BAMM simulates a
 
 
 Marginal shift probabilities
-------------------
+----------------------------
+
 The marginal shift probabilities on individual branches across the tree are of considerable interest. As discussed above, there are some nuances to interpreting these, because the probability associated with any particular branch is not independent of other branches in the tree. From your bammdata object, you can easily compute the branch-specific marginal shift probabilities with BAMMtools::
 	
 	library(BAMMtools)
@@ -106,7 +112,8 @@ You can convey this information in several possible ways. You can directly indic
 But don't get hung up on the fact that your shift probabilities are less than 0.95. Even *very* strongly supported rate heterogeneity will generally be associated with marginal shift probabilities < 0.95. As discussed :ref:`here<whalemarg1>`, you can (and often will) have exceptionally strong evidence for rate heterogeneity even if any given branch has marginal shift probabilities that do not appear particularly high. **Marginal shift probabilities tell you very little about the probability of rate heterogeneity in your dataset**. In principle, you could have high confidence that your data were shaped by a very large number of rate shifts, but at the same time find that no single branch has a marginal probability exceeding 0.10. 
 
 Maximum credibility shift configuration
-------------------
+---------------------------------------
+
 Marginal shift probabilities don't tell you much about the most likely sets of shifts that generated your dataset. One possible estimate of the *most likely shift configuration* is the **maximum credibility shift (MCS) configuration**. This concept is analogous to the *maximum clade credibility* tree in a Bayesian phylogenetic analysis. The MCS configuration is a rate shift configuration that was actually sampled by BAMM and which is one estimate of the best overall configuration. Formally, the MCS configuration is estimated in several steps. First, we compute the marginal shift probabilities on each branch of the tree. For the i\ :sup:`th` branch, denote this probability as p\ :sub:`i`. For each sample shift configuration from the posterior, we then compute the product of the observed set of shifts, using these marginal probabilities. These are then weighted by the posterior probability of sample *k* (as defined by the number of processes), or *P(k)*. The shift credibility score *C* for the k\ :sup:`th` sample is computed as: 
 
 .. math::
@@ -139,7 +146,7 @@ For publication, rather than (or in addition to) showing all shifts (or marginal
 
 
 Cumulative shift probabilities
-------------------
+------------------------------
 
 The *cumulative shift shift probability tree* shows the probability that a given node has evolutionary rate dynamics that are decoupled from the root process. For a given node to be decoupled from the "background" evolutionary dynamic, a rate shift must occur somewhere on the path between the node and the root of the tree. Branches with a cumulative shift probability of 1.0 imply that every sample in the posterior shows at least one rate shift between the focal branch and the root of the tree, leading to evolutionary dynamics that are decoupled from the background process. 
 
@@ -160,7 +167,7 @@ Here is another view of the whales analysis where we will use color to show all 
  
  
 Some complications with interpreting shift probabilities
------------------- 
+--------------------------------------------------------
 
 It is incorrect to assume that you need "significant" (p > 0.95) marginal shift probabilities or cumulative shift probabilities to demonstrate significant rate heterogeneity in your dataset. The evidence for rate heterogeneity comes from considering the posterior probabilities on the number of shifts, or - even better - the Bayes factor evidence in favor of model with *k* shifts (:math:`M_k`) relative to a model with 0 shifts (:math:`M_0`).
 
@@ -170,10 +177,3 @@ The primate body mass example dataset is a good example of this. Here, we have s
 
 
 
-
-
-
- 
-
- 
- 


### PR DESCRIPTION
I've fixed most of the syntax errors in the docs. Also set "template.rst" to be ignored.
