### PR TITLE
Fix "polytomy" msg for trees with dos line endings

### DIFF
--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -763,6 +763,7 @@ void Tree::buildTreeFromNewickString(std::string ts)
             readingBL = true;
         } else if (c == ';') {
             // done with tree
+            break;
         } else {
             std::string s = "";
             while (isValidChar(ts[i])) {


### PR DESCRIPTION
If you have a tree file with dos line endings (`xxd tree.tre` shows `0d0a`), bamm munches the newlines (probably because of `getline` somewhere) and complains about a polytomy, when in fact the parser has been filled with garbage. See the junk in `s` in the debugger below, and how `i` is huge.

```
Breakpoint 1, Tree::buildTreeFromNewickString (this=0x7fffffffd5b0, ts=
    "(((Polyodon_spathula:50.7052,Psephur"...) at /home/jonchang/bamm/src/Tree.cpp:791
791                             log(Error) << "Tree contains at least one polytomy.\n";
(gdb) info locals
q = 0xc76cf0
s =
    "\r", '\000' <repeats 11 times>"\341, \000\000\220\064j", '\000' <repeats 24 times>...
c = <value optimized out>
i = 306328
readingBL = <value optimized out>
p = <value optimized out>
```
