### PR TITLE
Trees with polytomies give opaque warning "ERROR: tree std::string"

### DIFF
--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -738,7 +738,7 @@ void Tree::buildTreeFromNewickString(std::string ts)
                 } else if (p->getRtDesc() == NULL) {
                     p->setRtDesc(q);
                 } else {
-                    std::cerr << "ERROR: tree std::string";
+                    log(Error) << "Tree contains at least one polytomy.\n";
                     exit(1);
                 }
             }


### PR DESCRIPTION
I inadvertently gave bamm a tree with a polytomous branching. The error message was "ERROR: tree std::string" - which I think comes from Line 740 of Tree.cpp (and not, say, L748 or L756). After much puzzling I figured out that the tree was not binary. Passing the tree through R/ape's _multi2di_ function allows bamm to  work. 

The attached pull request just makes this error message a bit more useful.
