### PR TITLE
Add autostopping feature based on ESS

### DIFF
--- a/src/MetropolisCoupledMCMC.cpp
+++ b/src/MetropolisCoupledMCMC.cpp
@@ -72,7 +72,7 @@ void MetropolisCoupledMCMC::run()
     } else {
         std::vector<double> nshifts;
         std::vector<double> loglik;
-        while (generation < _nGenerations || generation > _maxGenerations) {
+        while (generation < _maxGenerations) {
             int generationEnd = std::min(generation + _swapPeriod, _nGenerations);
             runChains(generation, generationEnd);
             generation = generationEnd;
@@ -83,7 +83,7 @@ void MetropolisCoupledMCMC::run()
                 nshifts.push_back(_chains[_coldChainIndex]->model().getNumberOfEvents());
                 loglik.push_back(_chains[_coldChainIndex]->model().getCurrentLogLikelihood());
             }
-            if (generation % _checkEvery == 0) {
+            if (generation > _nGenerations && generation % _checkEvery == 0) {
                 double nshifts_ess = Stat::ESS(nshifts, _burninFrac);
                 double loglik_ess = Stat::ESS(loglik, _burninFrac);
                 std::cout << std::endl << "NShifts ESS: " << nshifts_ess << " LogLik ESS: " << loglik_ess << " Target ESS: " << _ESS << std::endl;

--- a/src/MetropolisCoupledMCMC.cpp
+++ b/src/MetropolisCoupledMCMC.cpp
@@ -25,7 +25,6 @@ MetropolisCoupledMCMC::MetropolisCoupledMCMC
     // autostopping criteria
     _ESS = _settings.get<int>("convergenceESS");
     _checkEvery = _settings.get<int>("convergenceCheckFreq");
-    _maxGenerations = _settings.get<int>("convergenceMaxGenerations");
     _burninFrac = _settings.get<double>("convergenceBurninFrac");
     _outputFreq = _settings.get<int>("mcmcWriteFreq");
 
@@ -72,7 +71,7 @@ void MetropolisCoupledMCMC::run()
     } else {
         std::vector<double> nshifts;
         std::vector<double> loglik;
-        while (generation < _maxGenerations) {
+        while (generation < _nGenerations) {
             int generationEnd = std::min(generation + _swapPeriod, _nGenerations);
             runChains(generation, generationEnd);
             generation = generationEnd;
@@ -83,7 +82,7 @@ void MetropolisCoupledMCMC::run()
                 nshifts.push_back(_chains[_coldChainIndex]->model().getNumberOfEvents());
                 loglik.push_back(_chains[_coldChainIndex]->model().getCurrentLogLikelihood());
             }
-            if (generation > _nGenerations && generation % _checkEvery == 0) {
+            if (generation % _checkEvery == 0) {
                 double nshifts_ess = Stat::ESS(nshifts, _burninFrac);
                 double loglik_ess = Stat::ESS(loglik, _burninFrac);
                 std::cout << std::endl << "NShifts ESS: " << nshifts_ess << " LogLik ESS: " << loglik_ess << " Target ESS: " << _ESS << std::endl;

--- a/src/MetropolisCoupledMCMC.cpp
+++ b/src/MetropolisCoupledMCMC.cpp
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <thread>
-#include <iostream>
 
 
 MetropolisCoupledMCMC::MetropolisCoupledMCMC
@@ -71,6 +70,9 @@ void MetropolisCoupledMCMC::run()
     } else {
         std::vector<double> nshifts;
         std::vector<double> loglik;
+
+        log() << "\nStopping at ESS > " << _ESS << ", checking every " << _checkEvery << " generations w/ burnin " << _burninFrac << "\n\n";
+
         while (generation < _nGenerations) {
             int generationEnd = std::min(generation + _swapPeriod, _nGenerations);
             runChains(generation, generationEnd);
@@ -85,12 +87,12 @@ void MetropolisCoupledMCMC::run()
             if (generation % _checkEvery == 0) {
                 double nshifts_ess = Stat::ESS(nshifts, _burninFrac);
                 double loglik_ess = Stat::ESS(loglik, _burninFrac);
-                std::cout << std::endl << "NShifts ESS: " << nshifts_ess << " LogLik ESS: " << loglik_ess << " Target ESS: " << _ESS << std::endl;
+                log() << "\nNShifts ESS: " << nshifts_ess << " LogLik ESS: " << loglik_ess << "\n";
                 if (loglik_ess > _ESS && nshifts_ess > _ESS){
-                    std::cout << "Target ESS reached!" << std::endl;
+                    log() << "Target ESS of " << _ESS << " reached!\n";
                     break;
                 } else {
-                    std::cout << std::endl;
+                    log() << "\n";
                 }
             }
         }

--- a/src/MetropolisCoupledMCMC.h
+++ b/src/MetropolisCoupledMCMC.h
@@ -70,6 +70,10 @@ private:
     ModelDataWriter* _dataWriter;
 
     int _acceptanceResetFreq;
+
+    // convergence criteria
+    int _ESS, _checkEvery, _maxGenerations, _outputFreq;
+    double _burninFrac;
 };
 
 

--- a/src/MetropolisCoupledMCMC.h
+++ b/src/MetropolisCoupledMCMC.h
@@ -72,7 +72,7 @@ private:
     int _acceptanceResetFreq;
 
     // convergence criteria
-    int _ESS, _checkEvery, _maxGenerations, _outputFreq;
+    int _ESS, _checkEvery, _outputFreq;
     double _burninFrac;
 };
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -163,6 +163,13 @@ void Settings::initializeGlobalSettings()
     addParameter("fastSimulatePriorExperimental", "0", NotRequired);
     addParameter("fastSimulatePrior_BurnIn", "0.05", NotRequired);
 
+    // Convergence criterion parameters
+    addParameter("convergenceESS", "0", NotRequired);
+    addParameter("convergenceCheckFreq", "1000000", NotRequired);
+    addParameter("convergenceMaxGenerations", "10000000", NotRequired);
+    addParameter("convergenceBurninFrac", "0.1", NotRequired);
+
+
     // maxNumberEvents = for fastSimulatePriorExperimental, maximum number of events...
     // priorSims_intervalGenerations = number of generations per model pair
     // fastSimulatePrior_Generations = sampling gens for simulation of prior

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -166,7 +166,6 @@ void Settings::initializeGlobalSettings()
     // Convergence criterion parameters
     addParameter("convergenceESS", "0", NotRequired);
     addParameter("convergenceCheckFreq", "1000000", NotRequired);
-    addParameter("convergenceMaxGenerations", "10000000", NotRequired);
     addParameter("convergenceBurninFrac", "0.1", NotRequired);
 
 

--- a/src/Stat.cpp
+++ b/src/Stat.cpp
@@ -43,3 +43,61 @@ double Stat::lnExponentialPDF(double x, double rate)
 {
     return _random.lnExponentialPdf(rate, x);
 }
+
+
+// ESS code modified from RevBayes TraceAnalysisContinuous.cpp
+// originally written by Sebastian Hoehna, GPL License
+double Stat::ESS(const std::vector<double>& values, double burninFrac)
+{
+    if (values.size() <= 0) {
+        return 0;
+    }
+
+
+    double m = 0;
+    size_t size = values.size();
+    size_t burnin = floor(values.size() * burninFrac);
+    for (size_t ii = burnin; ii < size; ii++) {
+        m += values.at(ii);
+    }
+
+    double mean = m / double(size - burnin);
+
+    size_t samples = values.size() - burnin;
+    size_t maxLag = (samples - 1 < MAX_LAG ? samples - 1 : MAX_LAG);
+
+    double* gammaStat = new double[maxLag];
+    // setting values to 0
+    for (size_t i=0; i<maxLag; i++) {
+        gammaStat[i] = 0;
+    }
+    double varStat = 0.0;
+
+    for (size_t lag = 0; lag < maxLag; lag++) {
+        for (size_t j = 0; j < samples - lag; j++) {
+            double del1 = values.at(burnin + j) - mean;
+            double del2 = values.at(burnin + j + lag) - mean;
+            gammaStat[lag] += (del1 * del2);
+        }
+
+        gammaStat[lag] /= ((double) (samples - lag));
+
+        if (lag == 0) {
+            varStat = gammaStat[0];
+        } else if (lag % 2 == 0) {
+            // fancy stopping criterion :)
+            if (gammaStat[lag - 1] + gammaStat[lag] > 0) {
+                varStat += 2.0 * (gammaStat[lag - 1] + gammaStat[lag]);
+            }
+            // stop
+            else
+                maxLag = lag;
+        }
+    }
+
+    // effective sample size
+    double ess = samples / (varStat / gammaStat[0]);
+
+    delete[] gammaStat;
+    return ess;
+}

--- a/src/Stat.cpp
+++ b/src/Stat.cpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cmath>
+#include <cstddef>
 
 
 MbRandom Stat::_random;

--- a/src/Stat.h
+++ b/src/Stat.h
@@ -5,6 +5,7 @@
 #include "MbRandom.h"
 #include <vector>
 
+#define MAX_LAG 1000
 
 class Stat
 {
@@ -15,6 +16,8 @@ public:
 
     static double lnNormalPDF(double x, double mean, double sd);
     static double lnExponentialPDF(double x, double rate);
+
+    static double ESS(const std::vector<double>& values, double burninFrac);
 
 private:
 


### PR DESCRIPTION
This pull request adds the ability for BAMM to stop running if the effective sample size gets high enough.

This new feature can be tuned with the following parameters:

* `convergenceESS` - if the ESS of `N_shifts` and `logLik` exceed this value, the BAMM run stops
* `convergenceCheckFreq` - how often to check the ESS for convergence 
* `convergenceBurnin` - the fraction of samples to discard as burnin for calculating ESS

Setting `convergenceESS` to something other than 0 enables the autostopping feature. The `numberOfGenerations` parameter thus becomes the *maximum* number of generations that BAMM will run.

Currently only works for the Metropolis-coupled version of BAMM, but since MC3 is the default I assume this isn't a big deal.

The code for calculating effective sample size is modified from RevBayes, which is licensed under the GPL.