### PR TITLE
Add autoprior option

### DIFF
--- a/src/Prior.cpp
+++ b/src/Prior.cpp
@@ -2,6 +2,7 @@
 #include "Random.h"
 #include "Settings.h"
 #include "Stat.h"
+#include "Tree.h"
 
 #define _UPDATE_TOL 0.0001
 
@@ -54,6 +55,27 @@ Prior::Prior(Random& random, Settings* settings) : _random(random)
 
 Prior::~Prior()
 {
+}
+
+void Prior::autoInitializePriors(Tree* tree)
+{
+    // from BAMMtools::setBAMMpriors
+    // mbt <- max(branching.times(phy));
+    // pb <- (log(total.taxa) - log(2)) / mbt;
+    // lamprior <- 1 / (pb * 5);
+    // lamrootprior <- 1 / (pb * 1);
+    // k1 <- log(0.1) / mbt;
+    // kprior <- -1 * (k1 / 2);
+    double mbt = tree->getAge();
+    double total_taxa = nearbyint(tree->getNumberTips() * (1 / tree->samplingFrac));
+    double pb = (log(total_taxa) - log(2)) / mbt;
+    _muInitPrior = _lambdaInitPrior = 1 / (pb * 5);
+    double k1 = log(0.1) / mbt;
+    _lambdaShiftPrior = -1 * (k1 / 2);
+    std::cout << std::endl << "Autosetting priors {age=" << mbt << ", ntax=" << total_taxa << ", sf=" << tree->samplingFrac << "}" << std::endl;
+    std::cout << "    lambdaInitPrior = " << _lambdaInitPrior << std::endl;
+    std::cout << "    muInitPrior = " << _muInitPrior << std::endl;
+    std::cout << "    lambdaShiftPrior = " << _lambdaShiftPrior << std::endl;
 }
 
 

--- a/src/Prior.h
+++ b/src/Prior.h
@@ -9,6 +9,7 @@
 
 class Settings;
 class Random;
+class Tree;
 
 
 class Prior
@@ -53,6 +54,7 @@ public:
     double betaIsTimeVariablePrior();
     
     double preservationRatePrior(double);
+    void autoInitializePriors(Tree*);
     
     
 // Root priors:

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -209,6 +209,7 @@ void Settings::initializeSpeciationExtinctionSettings()
     addParameter("muShift0", "0.0", NotRequired);
 
     // Priors
+    addParameter("autoInitPriors", "0", NotRequired);
     addParameter("lambdaInitPrior", "0.0");
     addParameter("lambdaShiftPrior", "0.0");
     addParameter("muInitPrior", "0.0");

--- a/src/SpExModel.cpp
+++ b/src/SpExModel.cpp
@@ -38,6 +38,10 @@ SpExModel::SpExModel(Random& random, Settings& settings) :
     _muInit0 = _settings.get<double>("muInit0");
     _muShift0 = _settings.get<double>("muShift0");
 
+    if (_settings.get<bool>("autoInitPriors")) {
+        _prior.autoInitializePriors(_tree);
+    }
+
     _alwaysRecomputeE0 = _settings.get<bool>("alwaysRecomputeE0");
     
     

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -1124,6 +1124,7 @@ Node* Tree::chooseInternalNodeAtRandom()
 // TODO: check initialization for incomplete sampling for fossil process
 void Tree::initializeSpeciationExtinctionModel(double sampFrac)
 {
+    samplingFrac = sampFrac;
     double  speciationInit = sampFrac;
     double  extinctionInit = (double)1 - sampFrac;
 
@@ -1187,11 +1188,11 @@ void Tree::initializeSpeciationExtinctionModel(std::string fname)
 
     // First number in file is sampling probability for "backbone" of the tree
     getline(infile, tempstring, '\n');
-    double backboneSampProb = std::atof(tempstring.c_str());
-    double backboneInitial = 1.0 - backboneSampProb;
+    samplingFrac = std::atof(tempstring.c_str());
+    double backboneInitial = 1.0 - samplingFrac;
 
     // std::atof returns 0.0 if the conversion fails
-    if (backboneSampProb == 0.0) {
+    if (samplingFrac == 0.0) {
         log(Error) << "The first line of the sampling probability file\n"
                    << "must be the global sampling probability (> 0.0).\n";
         std::exit(1);

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -244,6 +244,7 @@ public:
 
     std::vector<Node*> terminalNodes();
     std::vector<double> traitValues();
+    double samplingFrac; // global sampling fraction
 };
 
 


### PR DESCRIPTION
Incorporate the BAMMtools function `setBAMMpriors` directly into BAMM.

Users can activate the autoprior function by setting the option `autoInitPriors = 1` in their control file.

The current implementation only works for speciation/extinction analyses. 
